### PR TITLE
Update threejs and @types/three version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.5.0
+---
+
+### Dependency Updates
+* **Updated Three.js**: Upgraded `three` from 0.168.0 to 0.177.0 (peerDependency)
+* **Updated @types/three**: Upgraded from 0.168.0 to 0.177.0 (devDependency)
+* **Updated threedgizmo**: Upgraded from ^0.6.0 to ^1.1.0 (dependency)
+
 2.4.3
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threedviewer",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "threedviewer",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "three-gpu-pathtracer": "^0.0.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "three-gpu-pathtracer": "^0.0.23",
-        "threedgizmo": "^0.6.0"
+        "threedgizmo": "^1.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -20,7 +20,7 @@
         "@types/lodash": "^4.17.7",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "@types/three": "0.168.0",
+        "@types/three": "0.177.0",
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",
         "@vitejs/plugin-react": "^4.3.1",
@@ -39,7 +39,7 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "three": "0.168.0"
+        "three": "0.177.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -550,6 +550,12 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -2476,9 +2482,12 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.168.0",
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==",
       "license": "MIT",
       "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
@@ -6972,7 +6981,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.168.0",
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
       "license": "MIT",
       "peer": true
     },
@@ -6996,14 +7007,15 @@
       }
     },
     "node_modules/threedgizmo": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/threedgizmo/-/threedgizmo-0.6.0.tgz",
-      "integrity": "sha512-1D+TwUDYbm0jztEZ/C6BBDXukvB8RBL6mSB6pggGFzYRhIonwixJIGeOYwDphbwjbgSceMBdZDihAG1XScT+Hg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/threedgizmo/-/threedgizmo-1.1.0.tgz",
+      "integrity": "sha512-1sY0FIzU1xUQ9d84C09YHr8QrFLRamuzkpnBI/IjNWH1SLplXLKptF3cXDtosDW5dST2PA3rdCxz1MSvfbjHtA==",
+      "license": "MIT",
       "peerDependencies": {
-        "@types/three": "0.168.0",
+        "@types/three": "0.177.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "three": "0.168.0"
+        "three": "0.177.0"
       }
     },
     "node_modules/tinyglobby": {
@@ -8004,6 +8016,11 @@
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "dev": true
+    },
+    "@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -9174,8 +9191,11 @@
       "version": "0.17.3"
     },
     "@types/three": {
-      "version": "0.168.0",
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==",
       "requires": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
@@ -12077,7 +12097,9 @@
       }
     },
     "three": {
-      "version": "0.168.0",
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
       "peer": true
     },
     "three-gpu-pathtracer": {
@@ -12094,9 +12116,9 @@
       "requires": {}
     },
     "threedgizmo": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/threedgizmo/-/threedgizmo-0.6.0.tgz",
-      "integrity": "sha512-1D+TwUDYbm0jztEZ/C6BBDXukvB8RBL6mSB6pggGFzYRhIonwixJIGeOYwDphbwjbgSceMBdZDihAG1XScT+Hg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/threedgizmo/-/threedgizmo-1.1.0.tgz",
+      "integrity": "sha512-1sY0FIzU1xUQ9d84C09YHr8QrFLRamuzkpnBI/IjNWH1SLplXLKptF3cXDtosDW5dST2PA3rdCxz1MSvfbjHtA==",
       "requires": {}
     },
     "tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/lodash": "^4.17.7",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/three": "0.168.0",
+    "@types/three": "0.177.0",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",
     "@vitejs/plugin-react": "^4.3.1",
@@ -68,11 +68,11 @@
   },
   "dependencies": {
     "three-gpu-pathtracer": "^0.0.23",
-    "threedgizmo": "^0.6.0"
+    "threedgizmo": "^1.1.0"
   },
   "peerDependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "three": "0.168.0"
+    "three": "0.177.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "threedviewer",
   "private": false,
-  "version": "2.4.3",
+  "version": "2.5.0",
   "type": "module",
   "description": "A 3D viewer based on React and Three.js",
   "keywords": [


### PR DESCRIPTION
### Task Description
Update the version of `threejs` as the current version is outdated and is creating conflicts with other packages

### Implementation Details
Update the following packages in the package.json and package-lock.json file:
- @types/three: 0.168.0 → 0.177.0 (devDependencies)
- threedgizmo: ^0.6.0 → ^1.1.0 (dependencies)
- three: 0.168.0 → 0.177.0 (peerDependencies)

### Demo and Testing
After the changes, the make build and make test are working fine with no errors:
 
<img width="1179" height="634" alt="Screenshot 2026-02-09 at 6 00 19 PM" src="https://github.com/user-attachments/assets/4f3870d6-34bb-45b9-a43c-0745c3365cd3" />

