### PR TITLE
[CAD-5161] Fix Texture type casts for Three.js r183

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.6.1
+---
+* Fix Texture type casts for Three.js r183
+
 2.6.0
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "three-gpu-pathtracer": "^0.0.23",
-        "threedgizmo": "^1.2.0"
+        "threedgizmo": "file:../threedgizmo/threedgizmo-1.2.0.tgz"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -20,7 +20,7 @@
         "@types/lodash": "^4.17.7",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/three": "0.177.0",
+        "@types/three": "0.183.1",
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",
         "@vitejs/plugin-react": "^4.3.1",
@@ -29,6 +29,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "three": "^0.183.2",
+        "three-mesh-bvh": "^0.9.9",
         "ts-jest": "^29.2.4",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.35.1",
@@ -41,7 +43,7 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "three": "0.177.0"
+        "three": ">=0.177.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1705,16 +1707,18 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.177.0",
+      "version": "0.183.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
+      "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
-        "@types/webxr": "*",
+        "@types/webxr": ">=0.5.17",
         "@webgpu/types": "*",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~1.0.1"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -5105,7 +5109,9 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -5989,9 +5995,10 @@
       }
     },
     "node_modules/three": {
-      "version": "0.177.0",
-      "license": "MIT",
-      "peer": true
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
     },
     "node_modules/three-gpu-pathtracer": {
       "version": "0.0.23",
@@ -6003,23 +6010,24 @@
       }
     },
     "node_modules/three-mesh-bvh": {
-      "version": "0.8.0",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.9.tgz",
+      "integrity": "sha512-FJKitcjvbALmeQRK+Sc+nLGorCpkrZBrbgJZFzhdyWboak37DZikn46hvQkNqSbJPm227ahYmS6k3N/GXaAyXw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "three": ">= 0.158.0"
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/threedgizmo": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/threedgizmo/-/threedgizmo-1.2.0.tgz",
-      "integrity": "sha512-/Lj94K5rzIP7uT5fAEck1TiDZXrd61Epa/Fd5+Aw3F+YZpHy1NrWdAZD8VzpMtfX2SdwNe/iVa9IuLCi0LE5Dw==",
+      "resolved": "file:../threedgizmo/threedgizmo-1.2.0.tgz",
+      "integrity": "sha512-lV4ss5/CZmdAnbBhQHeBDxGa+8LY+JbMH4R5ZIc3Z0d45RtdytmEAZWUZZmCyomcCqQuVSlM3E8X1F91qLKv7g==",
       "license": "MIT",
       "peerDependencies": {
-        "@types/three": "0.177.0",
+        "@types/three": ">=0.177.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "three": "0.177.0"
+        "three": ">=0.177.0"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "threedviewer",
   "private": false,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "description": "A 3D viewer based on React and Three.js",
   "keywords": [
@@ -53,7 +53,7 @@
     "@types/lodash": "^4.17.7",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/three": "0.177.0",
+    "@types/three": "0.183.1",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",
     "@vitejs/plugin-react": "^4.3.1",
@@ -62,6 +62,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "three": "^0.183.2",
+    "three-mesh-bvh": "^0.9.9",
     "ts-jest": "^29.2.4",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.35.1",
@@ -70,11 +72,11 @@
   },
   "dependencies": {
     "three-gpu-pathtracer": "^0.0.23",
-    "threedgizmo": "^1.2.0"
+    "threedgizmo": "^1.2.1"
   },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "three": "0.177.0"
+    "three": ">=0.177.0"
   }
 }

--- a/src/infrastructure/three/ThreeEnvironmentService.ts
+++ b/src/infrastructure/three/ThreeEnvironmentService.ts
@@ -296,7 +296,7 @@ class ThreeTextureAdapter implements ITexture {
   }
 
   get image(): HTMLImageElement | ImageData | HTMLCanvasElement | HTMLVideoElement | null {
-    return this.texture.image;
+    return this.texture.image as HTMLImageElement | ImageData | HTMLCanvasElement | HTMLVideoElement | null;
   }
 
   get needsUpdate(): boolean {

--- a/src/infrastructure/three/ThreePathTracingService.ts
+++ b/src/infrastructure/three/ThreePathTracingService.ts
@@ -432,20 +432,21 @@ export class ThreePathTracingService implements IPathTracingService {
               // Log scene contents before setting
 
               // For JPEG/PNG textures loaded via TextureLoader, ensure the image is loaded
-              if (originalEnvTexture.image && !originalEnvTexture.image.data) {
+              const texImage = originalEnvTexture.image as HTMLImageElement | (ImageData & { data?: unknown }) | null;
+              if (texImage && !("data" in texImage && texImage.data)) {
 
                 // If it's an HTMLImageElement, wait for it to load
-                if (originalEnvTexture.image instanceof HTMLImageElement && !originalEnvTexture.image.complete) {
+                if (texImage instanceof HTMLImageElement && !texImage.complete) {
                   await new Promise<void>((resolve) => {
-                    originalEnvTexture.image.onload = () => {
+                    texImage.onload = () => {
                       originalEnvTexture.needsUpdate = true;
                       resolve();
                     };
-                    originalEnvTexture.image.onerror = (_error: Event | string) => {
+                    texImage.onerror = (_error: Event | string) => {
                       resolve();
                     };
                     // If already loading, it should fire the onload event
-                    if (originalEnvTexture.image.complete) {
+                    if (texImage.complete) {
                       resolve();
                     }
                   });

--- a/src/infrastructure/three/ThreeScene.ts
+++ b/src/infrastructure/three/ThreeScene.ts
@@ -201,7 +201,7 @@ class ThreeTextureAdapter implements ITexture {
   }
 
   get image(): HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageData | null {
-    return this.texture.image || null;
+    return (this.texture.image as HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageData | null) || null;
   }
 
   get needsUpdate(): boolean {


### PR DESCRIPTION
### Task description

Fix Texture type casts for Three.js r183 compatibility

### Implementation details

- Add `as` type casts for `Texture.image` accesses in `ThreeEnvironmentService`, `ThreePathTracingService`, and `ThreeScene`
- Three.js 0.183 made `Texture` generic (`Texture<TImage = unknown>`), so `.image` is now typed as `unknown` instead of a concrete type

### Dependencies

- https://github.com/LEMing/ThreeDGizmo/pull/9